### PR TITLE
The initial version of Media File Manager to test accessibility by Users

### DIFF
--- a/BedBrigade.Client/Components/FileManager.razor
+++ b/BedBrigade.Client/Components/FileManager.razor
@@ -1,19 +1,99 @@
-﻿@using Syncfusion.Blazor.FileManager;
+﻿@using Syncfusion.Blazor.FileManager
+@using System.Diagnostics
+@using BedBrigade.Client.Components
+@inject NavigationManager NavigationManager
+@inject IJSRuntime jsRuntime
 
-
+<div class="row"><div class="col">&nbsp;</div></div>
+<div class="row">
+        <div class="col">
+           <h3>Media File Manager</h3>
+         </div>
+         <div class="col" style="text-align:right; font-size: small">                          
+              <i class="fa fa-user-circle-o" aria-hidden="true"></i>&nbsp;@userRole&nbsp;
+                @if (userLocationId > 1)
+                {
+                <span>[Folder: @userRoute]</span>
+                }
+                <br />@userName
+          </div>
+</div> 
+          
+<div class="row">
+<div class="col-md-12">
 <div class="control-section">
-    @* Initialization of default File Manager component *@
-    <SfFileManager TValue="FileManagerDirectoryContent" CssClass="file-manager">
-        <FileManagerAjaxSettings Url="https://localhost:7065/FileManager/FileOperations"
-                                 UploadUrl="https://localhost:7065/FileManager/Upload"
-                                 DownloadUrl="https://localhost:7065/FileManager/Download"
-                                 GetImageUrl="https://localhost:7065/FileManager/GetImage">
+        <SfFileManager  
+                TValue="FileManagerDirectoryContent"
+                CssClass="file-manager"
+                AllowMultiSelection="true"
+                Height="700px"
+                Width="100%"
+                >
+                <FileManagerAjaxSettings 
+                    Url="@dctUrlX["Operations"]"
+                    UploadUrl="@dctUrlX["Upload"]"
+                    DownloadUrl="@dctUrlX["Download"]"
+                    GetImageUrl="@dctUrlX["Image"]"
+        >
         </FileManagerAjaxSettings>
+                <FileManagerEvents TValue="FileManagerDirectoryContent" 
+                    OnSend="onsend"                    
+                    BeforeImageLoad="beforeImageLoad" 
+                >
+                </FileManagerEvents> 
+                <FileManagerUploadSettings
+                    AllowedExtensions="@AllowedExtensions"
+                    MaxFileSize="@MaxFileSize"
+                >
+                </FileManagerUploadSettings>
     </SfFileManager>
 </div>
+</div>
+</div>
 
-@code {
+@userLocationId<br />
+@userRoute
 
-    [Parameter] public string LocationId { get; set; }
+@code{
+
+    public string currentUrl=String.Empty;
+    public string? DownloadUrl { get; set; }
+    private Dictionary<string, string> dctUrlX = new Dictionary<string, string>();
+    public bool isRead = true;     
+
+    // custom data dictionary
+
+    protected override void OnInitialized()
+    {       
+        currentUrl = NavigationManager.BaseUri.ToString() + "FileManager/";
+        dctUrlX.Add("Operations", currentUrl+"FileOperations");
+        dctUrlX.Add("Upload", currentUrl + "Upload");
+        dctUrlX.Add("Download", currentUrl + "Download");
+        dctUrlX.Add("Image", currentUrl + "GetImage");
+    }
+
+    public void onsend(BeforeSendEventArgs args)    {      
+
+        if (isRead && args.Action == "read")
+        {
+            // send only not for national admin           
+
+            if (userLocationId>1) // Not Admin User
+            {
+                    args.HttpClientInstance.DefaultRequestHeaders.Add("rootfolder", userRoute); // UserPath cannot be empty
+            }
+            isRead = false;
+        }
+    }// onsend
+  
+    public void beforeImageLoad(BeforeImageLoadEventArgs<FileManagerDirectoryContent> args)
+    {      
+       if (userLocationId>1)
+       {
+           args.ImageUrl = args.ImageUrl + "&SubFolder=" + userRoute;
+       }
+    } // before Image Load
+
 
 }
+

--- a/BedBrigade.Client/Components/FileManager.razor.cs
+++ b/BedBrigade.Client/Components/FileManager.razor.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using System.Security.Claims;
+using BedBrigade.Client.Services;
+using static BedBrigade.Common.Common;
+
+namespace BedBrigade.Client.Components
+{
+    public partial class FileManager: ComponentBase
+    {
+       // Data Services
+        [Inject] private IConfigurationService? _svcConfiguration { get; set; }
+         
+        [Inject] private AuthenticationStateProvider? _authState { get; set; }
+        private ClaimsPrincipal? Identity { get; set; }
+                
+        private const string PathDivider = "/";       
+        private const string SubfolderKey = "MainMediaSubFolder";
+        private const string SiteRoot = "wwwroot/";
+        private string? MainAdminFolder { get; set; } = String.Empty;
+        private string @ErrorMessage = String.Empty;
+        private string MediaRoot = "wwwroot/media";      
+      
+        private Dictionary<string, string?> dctConfiguration { get; set; } = new Dictionary<string, string?>();
+        private string AllowedExtensions  = String.Empty;
+        private double MaxFileSize = 0;
+        private int userLocationId = 0;
+        private string userRoute = String.Empty;
+        private string userRole = String.Empty;
+        private string userName = String.Empty;
+              
+        //protected List<Location>? lstLocations;
+        
+        protected override async Task OnInitializedAsync()
+        {                
+            var authState = await _authState!.GetAuthenticationStateAsync();
+            Identity = authState.User;
+            userName = Identity.Identity.Name;
+            userLocationId = int.Parse(Identity.Claims.FirstOrDefault(c => c.Type == "LocationId").Value);
+            userRoute = Identity.Claims.FirstOrDefault(c => c.Type == "UserRoute").Value;
+            userRoute = userRoute.Replace(PathDivider, "");
+
+            if (Identity.IsInRole("National Admin")) // not perfect! for initial testing
+            {
+                userRole = "National Admin";
+                userLocationId = 1;                
+            }
+            else // Location User
+            {
+                if (Identity.IsInRole("Location Admin"))
+                {                   
+                    userRole = "Location Admin";
+                }
+
+                if (Identity.IsInRole("Location Author"))
+                {
+                   userRole = "Location Author";
+                }
+            }                 
+                       
+            var dataConfiguration = await _svcConfiguration.GetAllAsync(ConfigSection.Media); // Configuration ============================
+            if (dataConfiguration.Success && dataConfiguration != null)
+            {
+                dctConfiguration = dataConfiguration.Data.ToDictionary(keySelector: x => x.ConfigurationKey, elementSelector: x => x.ConfigurationValue);
+                AllowedExtensions = dctConfiguration["AllowedFileExtensions"].ToString() + "," + dctConfiguration["AllowedVideoExtensions"].ToString();
+                MaxFileSize = Convert.ToDouble(dctConfiguration["MaxVideoSize"]);
+                MediaRoot = SiteRoot + dctConfiguration["MediaFolder"];
+                MainAdminFolder = dctConfiguration[SubfolderKey];
+
+                if (userLocationId == 1)
+                {
+                    userRoute = MainAdminFolder;
+                }
+
+            }
+
+        } // Init
+
+
+
+    } // File Manager Class
+} // Namespace
+
+
+
+
+

--- a/BedBrigade.Client/Pages/Administration/Manage/FileManagerUse.razor
+++ b/BedBrigade.Client/Pages/Administration/Manage/FileManagerUse.razor
@@ -1,22 +1,6 @@
 ﻿@layout BedBrigade.Client.Shared.AdminLayout
 @page "/administration/manage/fm"
 @attribute [Authorize(Roles = "National Admin, Location Admin, Location Author")]
-@using Syncfusion.Blazor.FileManager;
 
-<div class="control-section">
-    @* Initialization of default File Manager component *@
-    <SfFileManager TValue="FileManagerDirectoryContent" CssClass="file-manager">
-        <FileManagerAjaxSettings Url="https://localhost:7065/FileManager/FileOperations"
-                                 UploadUrl="https://localhost:7065/FileManager/Upload"
-                                 DownloadUrl="https://localhost:7065/FileManager/Download"
-                                 GetImageUrl="https://localhost:7065/FileManager/GetImage">
-        </FileManagerAjaxSettings>
-    </SfFileManager>
-</div>
-
-<MediaGrid />
-
-@code {
-
-}
+<FileManager />
 

--- a/BedBrigade.Client/Pages/Administration/Manage/MediaFiles.razor
+++ b/BedBrigade.Client/Pages/Administration/Manage/MediaFiles.razor
@@ -1,6 +1,6 @@
 ﻿@layout BedBrigade.Client.Shared.AdminLayout
 @using BedBrigade.Client.Components
-@page "/administration/manage/mediafiles"
+@page "/administration/manage/mediagrid"
 @attribute [Authorize(Roles = "National Admin, Location Admin, Location Author")]
 
 <MediaGrid />

--- a/BedBrigade.Client/Shared/NavMenu.razor
+++ b/BedBrigade.Client/Shared/NavMenu.razor
@@ -93,7 +93,7 @@
         </AuthorizeView>
         <AuthorizeView Roles="National Admin, National Editor, Location Admin, Location Editor">
             <div class="nav-item px-3">
-                <NavLink class="nav-link" href="administration/manage/mediafiles">
+                <NavLink class="nav-link" href="administration/manage/fm">
                     <span class="oi oi-list-rich" aria-hidden="true"></span>Media
                 </NavLink>
             </div>


### PR DESCRIPTION
For testing by National & Location Admin users. Not implemented yet: 1) Blocking editing location folders for National Admin. 2) No file download for Location Admin. Will be improved in the next minor version. Also, this version does not validate Location Folders in /media root (they should exist).