### PR TITLE
Fixed header so the Admin menu would indicate active upon access

### DIFF
--- a/BedBrigade.Client/Components/Header.razor.cs
+++ b/BedBrigade.Client/Components/Header.razor.cs
@@ -1,3 +1,4 @@
+using BedBrigade.Client.Pages.Administration;
 using BedBrigade.Client.Services;
 using BedBrigade.Common;
 using Microsoft.AspNetCore.Components;
@@ -58,6 +59,10 @@ namespace BedBrigade.Client.Components
                     await _js.InvokeVoidAsync(SetInnerHTML, LoginElement, "Logout");
                     await _js.InvokeVoidAsync("SetGetValue.SetAttribute", LoginElement, "href", "/home/logout");
                     await _js.InvokeVoidAsync(SetInnerHTML, AdminElement, "Admin");
+                    if (Menu == "dashboard")
+                    {
+                        await _js.InvokeVoidAsync("AddRemoveClass.SetClass", AdminElement, "active");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
After logging in, the Admin menu would not indicate as the active menu. This fixes that.