### PR TITLE
Fixed Blazor error on Administration | Edit.

### DIFF
--- a/BedBrigade.Client/BedBrigade.Client.csproj
+++ b/BedBrigade.Client/BedBrigade.Client.csproj
@@ -66,6 +66,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="Pages\Administration\Edit\Stories.razor">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
     <Content Update="wwwroot\Media\national\pages\Home\Header\banner_img.jpg">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/BedBrigade.Client/Components/EditContent.razor
+++ b/BedBrigade.Client/Components/EditContent.razor
@@ -6,7 +6,6 @@
 @using Microsoft.AspNetCore.Components.Authorization;
 @using Syncfusion.Blazor.Grids;
 @using Syncfusion.Blazor.Notifications;
-@using System.Security.Claims;
 @using Action = Syncfusion.Blazor.Grids.Action;
 @using static BedBrigade.Common.Common;
 @using BedBrigade.Client.Pages.Administration.Manage;
@@ -134,9 +133,10 @@
 
 <style>
 
+
     .rte-container {
         width: 100%;
-        height: 900px;
+        height: 100%;
     }
     .e-toast-container {
         margin-top: 450px;

--- a/BedBrigade.Client/Pages/Administration/Edit/Bed.razor
+++ b/BedBrigade.Client/Pages/Administration/Edit/Bed.razor
@@ -1,0 +1,6 @@
+﻿@layout BedBrigade.Client.Shared.AdminLayout
+@page "/administration/edit/bed"
+@attribute [Authorize(Roles = "National Admin, Location Admin, National Author, Location Author, National Editor, Location Editor")]
+
+<EditContent PageName="RequestBed" />
+

--- a/BedBrigade.Client/Pages/Administration/Edit/Donate.razor
+++ b/BedBrigade.Client/Pages/Administration/Edit/Donate.razor
@@ -1,0 +1,6 @@
+﻿@layout BedBrigade.Client.Shared.AdminLayout
+@page "/administration/edit/donate"
+@attribute [Authorize]
+
+<EditContent PageName="donate" />
+

--- a/BedBrigade.Client/Pages/Administration/Edit/Stories.razor
+++ b/BedBrigade.Client/Pages/Administration/Edit/Stories.razor
@@ -1,0 +1,6 @@
+﻿@layout BedBrigade.Client.Shared.AdminLayout
+@page "/administration/edit/stories"
+@attribute [Authorize(Roles = "National Admin, Location Admin, National Author, Location Author, National Editor, Location Editor")]
+
+<EditContent PageName="Stories" />
+

--- a/BedBrigade.Client/Pages/Administration/Edit/Volunteer.razor
+++ b/BedBrigade.Client/Pages/Administration/Edit/Volunteer.razor
@@ -3,3 +3,4 @@
 @attribute [Authorize]
 
 <EditContent PageName="volunteer" />
+

--- a/BedBrigade.Client/StartupLogic.cs
+++ b/BedBrigade.Client/StartupLogic.cs
@@ -87,6 +87,11 @@ namespace BedBrigade.Client
             builder.Services.AddScoped<IMessageService, Services.MessageService>();
             builder.Services.AddScoped<IEmailService, EmailService>();
 
+            builder.Services.AddSignalR(e =>
+            {
+                e.MaximumReceiveMessageSize = 1024000;
+            });
+
             //services cors
             builder.Services.AddCors(p => p.AddPolicy("corsapp", builder =>
             {


### PR DESCRIPTION
Blazor would attempt to reconnect on specific pages when opening in the editor Administration | Edit. Fixed by increasing the receive message size of SignalR

Added additional pages to edit.