### PR TITLE
EmptyGridText "No matching records found" added to Configurations table

### DIFF
--- a/BedBrigade.Client/Components/EvolGrid.razor.cs
+++ b/BedBrigade.Client/Components/EvolGrid.razor.cs
@@ -124,10 +124,10 @@ namespace BedBrigade.Client.Components
 
         private async Task LoadGridData()
         {
+            await LoadConfiguration();
             await LoadUserData();
             await LoadLocations();
-            await LoadVolunteerData();
-            displayId = await EvolHelper.GetIdColumnsConfigurations(_svcConfiguration);
+            await LoadVolunteerData();            
             //await LoadScheduleData();
             Schedules = await EvolHelper.GetSchedules(_svcSchedule, isLocationAdmin, userLocationId); ;
             //await LoadVolunteerEvents();
@@ -136,7 +136,32 @@ namespace BedBrigade.Client.Components
             DisableToolBar();
             PrepareGridData();
         }
-               
+
+        private async Task LoadConfiguration()
+        {
+                        Dictionary<string, string?> dctConfiguration = new Dictionary<string, string?>();
+            var dataConfiguration = await _svcConfiguration.GetAllAsync(ConfigSection.System); // Configuration ============================
+            if (dataConfiguration.Success && dataConfiguration != null)
+            {
+                dctConfiguration = dataConfiguration.Data.ToDictionary(keySelector: x => x.ConfigurationKey, elementSelector: x => x.ConfigurationValue);
+                if (dctConfiguration != null)
+                {
+                    var DisplayIdFields = dctConfiguration["DisplayIdFields"].ToString();
+                    if (DisplayIdFields == "Yes")
+                    {
+                        displayId = true;
+                    }
+                    var EmptyGridText= dctConfiguration["EmptyGridText"].ToString();
+                    if(EmptyGridText!=null && EmptyGridText.Length > 0)
+                    {
+                        RecordText = EmptyGridText;
+                    }
+
+                }
+            }
+        } // Load Configuration
+
+
         private void DisableToolBar()
         {
             foreach (ItemModel tbItem in Toolbaritems)

--- a/BedBrigade.Common/ConfigNames.cs
+++ b/BedBrigade.Common/ConfigNames.cs
@@ -30,5 +30,6 @@
         public const string ReCaptchaSecret = "ReCaptchaSecret";
         public const string ReCaptchaSiteKey = "ReCaptchaSiteKey";
         public const string DisplayIdFields = "DisplayIdFields";
+        public const string EmptyGridText = "EmptyGridText";
     }
 }

--- a/BedBrigade.Data/Data/Seeding/Seed.cs
+++ b/BedBrigade.Data/Data/Seeding/Seed.cs
@@ -358,10 +358,16 @@ public class Seed
                     ConfigurationValue = "Bed Brigade NoReply",
                     Section = ConfigSection.Email
                 },
-                   new()
+                new()
                 {
                     ConfigurationKey = ConfigNames.DisplayIdFields,
                     ConfigurationValue = "No",
+                    Section = ConfigSection.System
+                },
+                new()
+                {
+                    ConfigurationKey = ConfigNames.EmptyGridText,
+                    ConfigurationValue = "No matching records found",
                     Section = ConfigSection.System
                 },
 


### PR DESCRIPTION
EmptyGridText "No matching records found" added to Configurations table ("System" section). This text can be changed by the System Admin. Implemented in the Event Volunteers grid, other grids could be changed at any time by developer decision.