### PR TITLE
Fix for circuit error

### DIFF
--- a/BedBrigade.Client/Components/App.razor
+++ b/BedBrigade.Client/Components/App.razor
@@ -15,10 +15,14 @@
     <link href="css/bedBrigade/navbar-top-fixed.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
     
+    @* The head outlet has to be placed before the component styles or it will cause this error if you click a link too fast: *@
+    @* (TypeError: Cannot read properties of null (reading 'insertBefore')) *@
+    @* See:  https://github.com/dotnet/aspnetcore/issues/54842 *@
+    <HeadOutlet @rendermode="RenderMode.InteractiveServer" />
+
     @* This is required for component styles to work *@
     <link rel="stylesheet" href="BedBrigade.Client.styles.css" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <HeadOutlet @rendermode="RenderMode.InteractiveServer" />
 </head>
 
 <body>

--- a/Documentation/Developer Gotchas.md
+++ b/Documentation/Developer Gotchas.md
@@ -7,6 +7,8 @@
         `@page "/{mylocation}/{mypageName:nonfile}"`
 * **Custom Authentication Broken in Blazor 8.** Blazor 8 needs to be jury rigged to get authentication to work.  See:  https://github.com/GregFinzer/Blazor8Auth
 
+* **(TypeError: Cannot read properties of null (reading 'insertBefore'))** The head outlet has to be placed before the component styles or it will cause this error if you click a link too fast.  See:  https://github.com/dotnet/aspnetcore/issues/54842
+
 ## Syncfusion Gotchas
 * **No grid custom validation.** When doing a dialog for add or edit  for Syncfusion, it cannot do any type of custom validation.  If you try to display errors in the middle of a template, it does not work.
 


### PR DESCRIPTION
The head outlet has to be placed before the component styles or it will cause this error if you click a link too fast:
(TypeError: Cannot read properties of null (reading 'insertBefore')) 
See:  https://github.com/dotnet/aspnetcore/issues/54842