### PR TITLE
Support different URL parameters

### DIFF
--- a/BedBrigade.Client/Components/Pages/Sorry.razor
+++ b/BedBrigade.Client/Components/Pages/Sorry.razor
@@ -1,33 +1,54 @@
 @page "/sorry"
 @page "/sorry/{mylocation}"
 @page "/sorry/{mylocation}/{mypageName}"
+@page "/{mylocation}/sorry/"
+@page "/{mylocation}/sorry/{mypageName}"
+
 @using Serilog
 <PageTitle>@_lc.Keys["Sorry"]</PageTitle>
-<h1 class="text-center mt-5">@_lc.Keys["SorryThePage"] </h1>
-@if (mylocation != null && mypageName != null)
+
+@if (IsLocationActive)
 {
-    <h2 class="text-center mt-5">@_lc.Keys["YouWereTryingTo"]: /@mylocation/@mypageName</h2>
+
+    <h1 class="text-center mt-5">@_lc.Keys["SorryThePage"] </h1>
+
+
+    @if (mylocation != null && mypageName != null)
+    {
+        <h2 class="text-center mt-5">@_lc.Keys["YouWereTryingTo"] /@mylocation/@mypageName</h2>
+    }
+    else if (mylocation != null)
+    {
+        <h2 class="text-center mt-5">@_lc.Keys["YouWereTryingTo"] /@mylocation</h2>
+    }
 }
-else if (mylocation != null)
+else
 {
-    <h2 class="text-center mt-5">@_lc.Keys["YouWereTryingTo"] /@mylocation</h2>
+    <h1 class="text-center mt-5">@_lc.Keys["LocationNotActive"] /@mylocation</h1>
 }
 
 <div class="text-center">
-    <a href="/" class="btn btn-primary">@_lc.Keys["ReturnToHome"]</a>
+    <a href="@HomeUrl" class="btn btn-primary">@_lc.Keys["ReturnToHome"]</a>
 </div>
 
 @code {
     [Inject] private ILanguageContainerService _lc { get; set; }
+    [Inject] private ILocationDataService _svcLocation { get; set; }
     [Parameter] public string? mylocation { get; set; }
     [Parameter] public string? mypageName { get; set; }
+
+    public string HomeUrl = "/";
+    private bool IsLocationActive = true;
 
     protected override void OnInitialized()
     {
         _lc.InitLocalizedComponent(this);
         if (mylocation != null && mypageName != null)
         {
+            HomeUrl = $"/{mylocation}";
+            CheckLocationStatus(mylocation);           
             Log.Logger.Warning($"404 for Page: /{mylocation}/{mypageName}");
+
         }
         else if (mylocation != null)
         {
@@ -37,5 +58,21 @@ else if (mylocation != null)
         {
             Log.Logger.Warning($"404 for Page: /sorry");
         }
-    }
+    } // init
+
+    private async void CheckLocationStatus(string location)
+    {        
+        var locationResponse = await _svcLocation.GetLocationByRouteAsync($"/{location}");
+
+        if (locationResponse.Success && locationResponse.Data != null)
+        {
+            IsLocationActive = locationResponse.Data.IsActive;
+            if (!IsLocationActive)
+            {
+                HomeUrl = $"/"; // return to national home
+            }
+        }
+        
+    } // location status
+
 }

--- a/BedBrigade.Client/Resources/en-US.yml
+++ b/BedBrigade.Client/Resources/en-US.yml
@@ -101,6 +101,7 @@ Loading: Loading....
 Location: Location
 LocationAvailableEvents: Location Available Events
 LocationColon: 'Location:'
+LocationNotActive: "We're sorry, this Bed Brigade location is no longer active: "
 LocationPathColon: 'Location Path:'
 LocationsMarkedWithAn: Locations marked with an asterisk (*) are currently inactive
 LogIn: Log In

--- a/BedBrigade.Client/Resources/es-MX.yml
+++ b/BedBrigade.Client/Resources/es-MX.yml
@@ -101,6 +101,7 @@ Loading: Carga....
 Location: Ubicación
 LocationAvailableEvents: Ubicación Disponible Eventos
 LocationColon: 'Ubicación:'
+LocationNotActive: 'Lo sentimos, este local de Bed Brigade ya no está activo: '
 LocationPathColon: 'Ruta de ubicación:'
 LocationsMarkedWithAn: Las ubicaciones marcadas con un asterisco (*) están actualmente inactivas
 LogIn: Inicia sesión

--- a/BedBrigade.Common/BedBrigade.Common.csproj
+++ b/BedBrigade.Common/BedBrigade.Common.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="KellermanSoftware.Serialization" Version="3.13.0" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />

--- a/BedBrigade.Common/Logic/UrlUtil.cs
+++ b/BedBrigade.Common/Logic/UrlUtil.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BedBrigade.Common.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace BedBrigade.Common.Logic
+{
+    public struct UrlContent
+    {
+        public int PositioningCount=0;
+        public bool IsParameterizedUrl;
+        public int QueryCount;
+        public string AcceptedLocationRoute;
+        public bool isLocationRoute;
+        public string AcceptedPageName;
+        public string FullUrl;
+        public string SorryPageUrl;
+        public string ErrorMessage;
+
+        public UrlContent()
+        {
+            PositioningCount = 0;
+            IsParameterizedUrl = false;
+            QueryCount = 0;
+            AcceptedLocationRoute = String.Empty;
+            isLocationRoute = false;
+            AcceptedPageName = String.Empty;
+            FullUrl = String.Empty;
+            SorryPageUrl = String.Empty;
+            ErrorMessage = String.Empty;
+        }
+    } // struct
+
+
+    public static class UrlUtil
+    {
+        public static UrlContent ValidateUrlContent(string url, bool IsLocationRoute = false)
+        {
+            var queryParams = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(); ;
+            UrlContent ValidatedUrl = new UrlContent();
+            ValidatedUrl.FullUrl = url.ToString();
+            ValidatedUrl.isLocationRoute = IsLocationRoute;
+
+            if (string.IsNullOrEmpty(url))
+            {
+                ValidatedUrl.ErrorMessage = "URL cannot be null or empty";
+                return (ValidatedUrl);
+            }
+
+            Uri uri = new Uri(url, UriKind.RelativeOrAbsolute);
+
+            // Get Positioning (Path) parameters
+            string[] pathSegments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            ValidatedUrl.PositioningCount = pathSegments.Length;
+
+            // Get Query parameters
+            var query = uri.Query;
+            
+            if (!string.IsNullOrEmpty(query))
+            {
+                queryParams = QueryHelpers.ParseQuery(query);
+                ValidatedUrl.QueryCount = queryParams.Count;
+            }
+            // Parameterized URL ?
+
+            if (ValidatedUrl.PositioningCount == 0 && ValidatedUrl.QueryCount == 0)
+            { // no parameters
+                ValidatedUrl.IsParameterizedUrl = false;
+                return (ValidatedUrl);
+            }
+            else
+            {
+                ValidatedUrl.IsParameterizedUrl = true;
+            }
+
+            // Validate Positioning Parameters Values
+
+            CheckPositioningParameters(ref ValidatedUrl, IsLocationRoute, pathSegments);
+
+            if (ValidatedUrl.QueryCount > 0)
+            {
+                switch (ValidatedUrl.QueryCount)
+                {
+                    case 1: // single query parameter - location - NOTE: no location validation at this time
+                        if (queryParams.TryGetValue("location", out var locationValue))
+                        {
+                            if (!String.IsNullOrEmpty(locationValue))
+                            {
+                                ValidatedUrl.AcceptedLocationRoute = StringUtil.IsNull(locationValue,"");
+                            }
+                            ValidatedUrl.AcceptedPageName = GetPageNameWithoutQuery(uri);
+                        }
+                                              
+                        break;
+                    default:
+                        ValidatedUrl.ErrorMessage = "URL contains unknown query parameters";
+                        break;
+                }
+            } // query parameters
+
+            // set sorry page URL depend of context
+            SetSorryUrl(ref ValidatedUrl);
+           
+            return (ValidatedUrl);
+
+        }//ValidateUrlContent
+
+        public static void CheckPositioningParameters(ref UrlContent ValidatedUrl, bool IsLocationRoute, string[] pathSegments)
+        {
+            // Validate Positioning Parameters Values
+
+            if (ValidatedUrl.PositioningCount > 0)
+            {
+
+                switch (ValidatedUrl.PositioningCount)
+                {
+                    case 1: // single parameter: location or page
+                        if (IsLocationRoute)
+                        {
+                            ValidatedUrl.AcceptedLocationRoute = pathSegments[0];
+                        }
+                        else
+                        {
+                            ValidatedUrl.AcceptedPageName = pathSegments[0];
+                        }
+                        break;
+
+                    case 2: // dual parameters: location/page
+
+                        ValidatedUrl.AcceptedLocationRoute = pathSegments[0];
+                        ValidatedUrl.AcceptedPageName = pathSegments[1];
+                        break;
+
+                    default:
+                        // unknown parameters
+                        ValidatedUrl.ErrorMessage = "URL contains unknown positioning parameters";
+                        break;
+                }
+            } // Positioning Count > 0
+        } // Check Positioning
+
+
+        public static void SetSorryUrl(ref UrlContent ValidatedUrl)
+        {
+            var SorryUrl = String.Empty;
+            // national context - location could be ignored
+            if (ValidatedUrl.AcceptedLocationRoute.Equals("National", StringComparison.CurrentCultureIgnoreCase))
+            {
+                SorryUrl = $"/Sorry/{ValidatedUrl.AcceptedPageName}";
+            }
+            else // location context
+            {
+                if (ValidatedUrl.AcceptedLocationRoute.Length > 0)
+                {
+                    SorryUrl = $"/{ValidatedUrl.AcceptedLocationRoute}/Sorry";
+                }
+                else
+                {
+                    SorryUrl = "/Sorry";
+                }
+
+                if (!String.IsNullOrEmpty(ValidatedUrl.AcceptedPageName))
+                {
+                    SorryUrl += $"/{ValidatedUrl.AcceptedPageName}";
+                }
+            }
+
+            ValidatedUrl.SorryPageUrl = SorryUrl;
+        } // Create Sorry Url
+
+
+        public static string GetPageNameWithoutQuery(Uri uri)
+        {
+            // Get the absolute path and split by '/'
+            var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            // Get the last segment, which may include query parameters
+            var lastSegment = segments.LastOrDefault();
+
+            // Check if last segment is null or empty, and then strip off any query parameters if present
+            if (!string.IsNullOrEmpty(lastSegment))
+            {
+                var indexOfQuery = lastSegment.IndexOf("?");
+                if (indexOfQuery >= 0)
+                {
+                    lastSegment = lastSegment.Substring(0, indexOfQuery);
+                }
+            }
+
+            return lastSegment;
+
+        } // Get Page Banem without query
+        
+
+
+    } // class
+} // namespace


### PR DESCRIPTION
The pages **index.razor** & **sorry.razor** are modified to support different URL models used across the site, such as /pagename, /location/pagename, and /pagename?location=location. 
New common utility file UrlUtil.cs created. 
Also, page "Sorry" will be used to show localized message about not-active location.